### PR TITLE
Fix deps.edn and an hiccup example

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,8 @@
  :deps
  {org.clojure/clojure {:mvn/version "1.10.1"}
   scicloj/notespace   {:mvn/version "3-alpha3-SNAPSHOT"}
-  scicloj/tablecloth  {:mvn/version "5.00-beta-2"}}
+  scicloj/tablecloth  {:mvn/version "5.00-beta-2"}
+  djblue/portal {:mvn/version "0.6.4"}}
 
  :aliases
  {

--- a/src/practicalli/notespace_demo.clj
+++ b/src/practicalli/notespace_demo.clj
@@ -44,8 +44,8 @@
 ^kind/hiccup
 [:div
  (->> (range 9)
-      (map (fn [i] [:h1 i])
-           (into [:div])))]
+      (map (fn [i] [:h1 i]))
+      (into [:div]))]
 
 
 ^kind/hiccup-nocode


### PR DESCRIPTION
To run the example with `deps.edn`, the portal dependency must be set.

There was an arity error with an hiccup example. It wast just one structural edit distance mistake.